### PR TITLE
surfaceflinger: Fix for non-qcom devices

### DIFF
--- a/services/surfaceflinger/DispSync.h
+++ b/services/surfaceflinger/DispSync.h
@@ -26,8 +26,12 @@
 namespace android {
 
 // Ignore present (retire) fences if the device doesn't have support for the
-// sync framework.
-#if defined(RUNNING_WITHOUT_SYNC_FRAMEWORK)
+// sync framework, or if all phase offsets are zero on non-QCOM_BSP. The latter is useful
+// because it allows us to avoid resync bursts on devices that don't need
+// phase-offset VSYNC events.
+#if defined(RUNNING_WITHOUT_SYNC_FRAMEWORK) || \
+        (VSYNC_EVENT_PHASE_OFFSET_NS == 0 && SF_VSYNC_EVENT_PHASE_OFFSET_NS == 0 && \
+        !defined(QCOM_BSP))
 static const bool kIgnorePresentFences = true;
 #else
 static const bool kIgnorePresentFences = false;


### PR DESCRIPTION
* Commit 7ab63c4e390a7348cddebe1e80d5f78210235f99 removed the ability
  to auto-detect if a device needs to ignore present (retire) fences

Change-Id: Ib7b7e9b0e6de0fda11f7c397bc3998ae165d8ca1